### PR TITLE
fixed bug when viewing exercises

### DIFF
--- a/client/src/components/dashboard/Dashboard.js
+++ b/client/src/components/dashboard/Dashboard.js
@@ -60,18 +60,26 @@ class Dashboard extends Component {
   handleChosen = event => {
     let { dataset } = event.target;
 
-    this.setState({ programChosen: dataset.program });
+    //WORKING
+    this.setState({ programChosen: dataset.program }, () => {
+      this.getExcercises(this.state.programChosen);
+    });
 
-    console.log(this.state.programChosen);
+    //OLD
+    // console.log(this.state.programChosen);
 
-    if (this.state.programChosen) {
-      let programChosen = this.state.programChosen;
-      this.getExcercises(programChosen);
-    }
+    // if (this.state.programChosen) {
+    //   let programChosen = this.state.programChosen;
+    //   this.getExcercises(programChosen);
+    // }
   };
 
   handleViewPrograms = () => {
-    this.setState({ workoutChosen: false, programChosen: '', programExcercises: '' });
+    this.setState({
+      workoutChosen: false,
+      programChosen: '',
+      programExcercises: ''
+    });
     console.log(this.state);
   };
 


### PR DESCRIPTION
When viewing exercises, the first click didn't register because state wasn't set. This fix runs the getExercises method after state is set.